### PR TITLE
HTTP status code messages are not passed through

### DIFF
--- a/cgistream.php
+++ b/cgistream.php
@@ -112,22 +112,26 @@ class CGIStream
                     
                     if (isset($headers['Status']))
                     {
-                        $status = (int) $headers['Status'];
+                        $separator = strpos($headers['Status'], ' ');
+                        $status = (int) substr($headers['Status'], 0, $separator);
+                        $status_msg = trim(substr($headers['Status'], $separator));
                         unset($headers['Status']);
                     }                
                     else
                     {
                         $status = 200;
-                    }                
-                    
+                        $status_msg = null;
+                    }
+
                     $content = substr($buffer, $end_response_headers + 4);                            
-                    $response = $this->server->response($status, $content, $headers);
+                    $response = $this->server->response($status, $content, $headers, $status_msg);
                 }
                 
                 // set status and headers on the server's HTTPResponse object.
                 // these aren't actually sent to the client,
                 // but they could be referenced by HTTPServer::get_log_line                
                 $this->response->status = $response->status;
+                $this->response->status_msg = $response->status_msg;
                 $this->response->headers = $response->headers;
                     
                 $this->cur_state = static::BUFFERED;                

--- a/httpresponse.php
+++ b/httpresponse.php
@@ -8,7 +8,8 @@
  
 class HTTPResponse
 {
-    public $status;                 // HTTP status code    
+    public $status;                 // HTTP status code
+    public $status_msg;         // HTTP status message
     public $headers;                // associative array of HTTP headers 
     
     public $content = '';           // response body, as string (optional)    
@@ -20,10 +21,11 @@ class HTTPResponse
     public $buffer = '';            // buffer of HTTP response waiting to be written to client socket
     public $bytes_written = 0;      // count of bytes written to client socket
 
-    function __construct($status = 200, $content = '', $headers = null)
+    function __construct($status = 200, $content = '', $headers = null, $status_msg = null)
     {
         $this->status = $status;
-        
+        $this->status_msg = $status_msg;
+
         if (is_resource($content))
         {
             $this->stream = $content;
@@ -45,9 +47,13 @@ class HTTPResponse
         return !$this->stream || feof($this->stream);
     }    
         
-    static function render_status($status)
-    {    
-        $status_msg = static::$status_messages[$status];
+    static function render_status($status, $status_msg)
+    {
+        // Per RFC2616 6.1.1 we pass on a status message from the provider if
+        // provided, otherwise we use the standard message for that code.
+        if (empty($status_msg)) {
+          $status_msg = static::$status_messages[$status];
+        }
         return "HTTP/1.1 $status $status_msg\r\n";
     }
     
@@ -71,7 +77,7 @@ class HTTPResponse
             $headers['Content-Length'] = $this->get_content_length();
         }        
         
-        return  static::render_status($this->status).
+        return  static::render_status($this->status, $this->status_msg).
                 static::render_headers($headers).
                 $this->content;
     }

--- a/httpserver.php
+++ b/httpserver.php
@@ -298,9 +298,9 @@ class HTTPServer
     /*
      * Returns a generic HTTPResponse object for this server.
      */
-    function response($status = 200, $content = '', $headers = null)
+    function response($status = 200, $content = '', $headers = null, $status_msg = null)
     {
-        $response = new HTTPResponse($status, $content, $headers);        
+        $response = new HTTPResponse($status, $content, $headers, $status_msg);
         $response->headers['Server'] = $this->server_id;                
         return $response;        
     }


### PR DESCRIPTION
According to http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1 localized HTTP status code messages are acceptable, and Apache passes them though. This adds code to parse out the message from the CGI and pass it through if non empty.
https://github.com/youngj/httpserver/issues/1
