### PR TITLE
Composer support for HTTPServer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor
+composer.lock
+composer.phar

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "youngj/httpserver",
+    "description": "A simple HTTP server, written in PHP, that serves PHP scripts and static files.",
+    "type": "library",
+    "homepage": "https://github.com/youngj/httpserver",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jesse Young",
+            "homepage": "https://github.com/youngj"
+        }
+    ],
+    "require": {
+        "php": ">=5.3"
+    },
+    "suggest": {
+        "php-cgi": "HTTPServer requires the php-cgi binary."
+    },
+    "autoload": {
+        "classmap": [
+            "cgistream.php",
+            "httprequest.php",
+            "httpresponse.php",
+            "httpserver.php"
+        ]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a dependency management system for PHP packages. This pull request adds Composer support to HTTPServer. Having this means that a project can use something like the following in a composer.json to depict a dependency on Console_Color:

```
"require": {
    "youngj/httpserver": "*"
}
```

If you run a Composer install on that, it will download HTTPServer, and map out all the class mappings appropriately through autoload.php.

```
curl -s http://getcomposer.org/installer | php
php composer.phar install
```
