### PR TITLE
revert short array syntax for 5.3 compatibility

### DIFF
--- a/httprequest.php
+++ b/httprequest.php
@@ -202,7 +202,7 @@ class HTTPRequest
                     if ($chunk_len_remaining == 0)
                     {
                         $this->cur_state = static::READ_COMPLETE;
-                        $this->headers['Content-Length'] = $this->lc_headers['content-length'] = [$this->content_len];
+                        $this->headers['Content-Length'] = $this->lc_headers['content-length'] = array($this->content_len);
                         
                         // todo: this is where we should process trailers...
                         return;

--- a/httpresponse.php
+++ b/httpresponse.php
@@ -85,7 +85,7 @@ class HTTPResponse
 
         if (!isset($headers['Content-Length']))
         {
-            $headers['Content-Length'] = [$this->get_content_length()];
+            $headers['Content-Length'] = array($this->get_content_length());
         }        
         
         return  static::render_status($this->status, $this->status_msg).

--- a/httpserver.php
+++ b/httpserver.php
@@ -496,7 +496,7 @@ class HTTPServer
                 
                 if (!isset($headers[$header_name]))
                 {
-                    $headers[$header_name] = [$value];
+                    $headers[$header_name] = array($value);
                 }
                 else
                 {


### PR DESCRIPTION
replaces short array syntax with `array()` to preserve PHP 5.3 compatibilty.

see #9
